### PR TITLE
Fix sourcemap autogeneration error message

### DIFF
--- a/lua/luau-lsp/sourcemap.lua
+++ b/lua/luau-lsp/sourcemap.lua
@@ -71,7 +71,13 @@ function M.generate()
     args = args,
     on_exit = function(self, code)
       if code ~= 0 then
-        vim.notify(self:stderr_result(), vim.log.levels.ERROR, { title = "luau lsp" })
+        vim.schedule(function()
+          vim.notify(
+            table.concat(self:stderr_result(), "\n"),
+            vim.log.levels.ERROR,
+            { title = "luau lsp" }
+          )
+        end)
       end
     end,
   }):start()


### PR DESCRIPTION
When a project file doesn't exist in the working directory, I get the following error:
![image](https://user-images.githubusercontent.com/23710811/228036172-8f0a5ed3-6894-49bc-83d5-9115342fb922.png)

This is due to calling `vim.notify` within a Plenary job. I fixed this by wrapping the call in `vim.schedule`. Also, since `stderr_result` is an array, but `vim.notify` expects the first argument to be a string, I converted it using `table.concat`.

Now I can see the actual error message!
![image](https://user-images.githubusercontent.com/23710811/228068775-6e800ea7-b01b-45e0-8ae9-c9c5ed2fa63b.png)
