### PR TITLE
Fix missing comma for lazy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/lopi-py/luau-lsp.nvim/assets/70210066/4fa6d3b1-44fe-414f-96ff
 ```lua
 {
   "lopi-py/luau-lsp.nvim",
-  ft = { "luau" }
+  ft = { "luau" },
   opts = {
     ...
   },


### PR DESCRIPTION
What it says on the tin - there's a missing comma in README.md for the lazy install script. I just noticed it while going through the install procedure, so may as well fix it.