### PR TITLE
Make treesitter warning message clear that it is coming from luau-lsp

### DIFF
--- a/lua/luau-lsp/init.lua
+++ b/lua/luau-lsp/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.treesitter()
   local log = require "luau-lsp.log"
-  log.warn "A custom treesitter parser is not longer required at all"
+  log.warn "Luau-lsp no longer requires a custom treesitter parser"
 end
 
 ---@param opts LuauLspConfig


### PR DESCRIPTION
When updating my plugins in bulk, I had trouble finding where this mysterious "A custom treesitter parser is not longer required at all" was coming from. This change makes it clear that luau-lsp is the one throwing the warning message.