### PR TITLE
Fix studio plugin server not starting up

### DIFF
--- a/lua/luau-lsp/studio.lua
+++ b/lua/luau-lsp/studio.lua
@@ -113,6 +113,10 @@ local function restart_server()
 end
 
 function M.setup()
+  if config.get().plugin.enabled then
+    restart_server()
+  end
+
   vim.api.nvim_create_autocmd("LspAttach", {
     callback = function(args)
       local client = vim.lsp.get_client_by_id(args.data.client_id)


### PR DESCRIPTION
Fix #20 

This reverts
```lua
if config.get().plugin.enabled then
  restart_server()
end
```
that was removed on this [commit](https://github.com/lopi-py/luau-lsp.nvim/commit/10116d301681f3e23f4bc35c3179bac576262acd#diff-f8e5f584075200920258cc732801510ef93685e021a66345ac363e74cb14f2b1L112-L114).

Any reasons why it got removed?
