### PR TITLE
Fixed edgecase regarding root_dir

### DIFF
--- a/lua/luau-lsp/config.lua
+++ b/lua/luau-lsp/config.lua
@@ -55,7 +55,7 @@ local defaults = {
         "stylua.toml",
         "selene.toml",
         "selene.yml",
-      })
+      }) or vim.fn.getcwd()
     end,
   },
 }


### PR DESCRIPTION
In case no root_dir was found, it would remain a function, causing issues down the line when trying to start the LSP.

More is discussed in #26

Also closes #26 